### PR TITLE
lilac: fix slimbus on some audio usecases

### DIFF
--- a/rootdir/vendor/etc/mixer_paths.xml
+++ b/rootdir/vendor/etc/mixer_paths.xml
@@ -719,7 +719,7 @@
     </path>
 
     <path name="deep-buffer-playback headphones">
-        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia1" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia1" value="1" />
     </path>
 
     <path name="deep-buffer-playback speaker-and-headphones">
@@ -820,7 +820,7 @@
     </path>
 
     <path name="low-latency-playback headphones">
-        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia5" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia5" value="1" />
     </path>
 
     <path name="low-latency-playback speaker-and-headphones">
@@ -879,7 +879,7 @@
     </path>
 
     <path name="audio-ull-playback headphones">
-        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia3" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia3" value="1" />
     </path>
 
     <path name="audio-ull-playback speaker-and-headphones">
@@ -1060,7 +1060,7 @@
     </path>
 
     <path name="compress-offload-playback2 headphones">
-        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia7" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia7" value="1" />
     </path>
 
     <path name="compress-offload-playback2 headphones-44.1">
@@ -1183,7 +1183,7 @@
     </path>
 
     <path name="compress-offload-playback4 headphones">
-        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia11" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia11" value="1" />
     </path>
 
     <path name="compress-offload-playback4 headphones-44.1">
@@ -1244,7 +1244,7 @@
     </path>
 
     <path name="compress-offload-playback5 headphones">
-        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia12" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia12" value="1" />
     </path>
 
     <path name="compress-offload-playback5 headphones-44.1">
@@ -1305,7 +1305,7 @@
     </path>
 
     <path name="compress-offload-playback6 headphones">
-        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia13" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia13" value="1" />
     </path>
 
     <path name="compress-offload-playback6 headphones-44.1">
@@ -1366,7 +1366,7 @@
     </path>
 
     <path name="compress-offload-playback7 headphones">
-        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia14" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia14" value="1" />
     </path>
 
     <path name="compress-offload-playback7 headphones-44.1">
@@ -1427,7 +1427,7 @@
     </path>
 
     <path name="compress-offload-playback8 headphones">
-        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia15" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia15" value="1" />
     </path>
 
     <path name="compress-offload-playback8 headphones-44.1">
@@ -1488,7 +1488,7 @@
     </path>
 
     <path name="compress-offload-playback9 headphones">
-        <ctl name="SLIMBUS_6_RX Audio Mixer MultiMedia16" value="1" />
+        <ctl name="SLIMBUS_0_RX Audio Mixer MultiMedia16" value="1" />
     </path>
 
     <path name="compress-offload-playback9 headphones-44.1">


### PR DESCRIPTION
following changes
https://github.com/sonyxperiadev/device-sony-yoshino/commit/39d8acf7ad67bf9cce5ee1d9ab05d873b225d783#diff-74fc16bd814a72729b516a1988c9fda1R98

Signed-off-by: David Viteri <davidteri91@gmail.com>