### PR TITLE
Remove fingerprintd from PRODUCT_PACKAGES

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -77,7 +77,6 @@ PRODUCT_PACKAGES += \
 
 # Fingerprint HAL
 PRODUCT_PACKAGES += \
-    fingerprintd \
     fingerprint.lilac
 
 # NFC config


### PR DESCRIPTION
* This package no longer exists on 8.0,
  it has been replaced with fingerprint HIDL
  service.