### PR TITLE
[master] BoardConfig: Remove NXP_CHIP_TYPE flag

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -26,7 +26,6 @@ endif
 PRODUCT_PLATFORM := yoshino
 
 # NFC
-NXP_CHIP_TYPE := PN553
 NXP_CHIP_FW_TYPE := PN553
 
 BOARD_KERNEL_CMDLINE += androidboot.hardware=lilac


### PR DESCRIPTION
This flag no longer exist in Android P.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>